### PR TITLE
Update README to inform students to install yarn

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,4 +2,12 @@
 
 > Workshop on testing Vue applications
 
+## Requirements
+
+- [yarn](https://yarnpkg.com/lang/en/docs/install/#mac-stable)\*
+
+\* There have been some issues with `npm install`, so the exercises in this repo use a `yarn.lock` instead.
+
+## Resources
+
 Slides available at https://slides.com/eddyerburgh/testing-workshop

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ## Requirements
 
-- [yarn](https://yarnpkg.com/lang/en/docs/install/#mac-stable)\*
+- [yarn](https://yarnpkg.com/lang/en/docs/install/)\*
 
 \* There have been some issues with `npm install`, so the exercises in this repo use a `yarn.lock` instead.
 

--- a/README.md
+++ b/README.md
@@ -10,4 +10,4 @@
 
 ## Resources
 
-Slides available at https://slides.com/eddyerburgh/testing-workshop
+Slides available at https://slides.com/eddyerburgh/testing-vue-workshop


### PR DESCRIPTION
Since you mentioned at the beginning of the workshop that yarn is preferred over npm, so I thought it would be nice to make a note of it in the README.